### PR TITLE
Use volatile register r11 to store syscall address

### DIFF
--- a/syswhispers.py
+++ b/syswhispers.py
@@ -353,9 +353,11 @@ class SysWhispers(object):
                     code += '\n\t\t"call SW3_GetRandomSyscallAddress \\n"'
                 else:
                     code += '\n\t\t"call SW3_GetSyscallAddress \\n"'
-                code += '\n\t\t"mov r11, rax \\n"'
+                code += '\n\t\t"mov [rsp+20h], rax \\n"'
                 code += f'\n\t\t"mov ecx, 0x{function_hash:08X} \\n"'
             code += '\n\t\t"call SW3_GetSyscallNumber \\n"'
+            if self.recovery in [SyscallRecoveryType.JUMPER, SyscallRecoveryType.JUMPER_RANDOMIZED]:            
+                code += '\n\t\t"mov r11, [rsp+20h] \\n"'
             code += '\n\t\t"add rsp, 0x28 \\n"'
             code += '\n\t\t"mov rcx, [rsp+8] \\n"'
             code += '\n\t\t"mov rdx, [rsp+16] \\n"'
@@ -486,9 +488,11 @@ class SysWhispers(object):
                     code += '\tcall SW3_GetRandomSyscallAddress        ; Get a syscall offset from a different api.\n'
                 else:
                     code += '\tcall SW3_GetSyscallAddress              ; Resolve function hash into syscall offset.\n'
-                code += '\tmov r11, rax                           ; Save the address of the syscall\n'
+                code += '\tmov [rsp+20h], rax                           ; Save the address of the syscall\n'
                 code += f'\tmov ecx, 0{function_hash:08X}h        ; Re-Load function hash into ECX (optional).\n'
             code += '\tcall SW3_GetSyscallNumber              ; Resolve function hash into syscall number.\n'
+            if self.recovery in [SyscallRecoveryType.JUMPER, SyscallRecoveryType.JUMPER_RANDOMIZED]:
+                code += '\tmov r11, [rsp+20h]'
             code += '\tadd rsp, 28h\n'
             code += '\tmov rcx, [rsp+8]                      ; Restore registers.\n'
             code += '\tmov rdx, [rsp+16]\n'

--- a/syswhispers.py
+++ b/syswhispers.py
@@ -353,7 +353,7 @@ class SysWhispers(object):
                     code += '\n\t\t"call SW3_GetRandomSyscallAddress \\n"'
                 else:
                     code += '\n\t\t"call SW3_GetSyscallAddress \\n"'
-                code += '\n\t\t"mov r15, rax \\n"'
+                code += '\n\t\t"mov r11, rax \\n"'
                 code += f'\n\t\t"mov ecx, 0x{function_hash:08X} \\n"'
             code += '\n\t\t"call SW3_GetSyscallNumber \\n"'
             code += '\n\t\t"add rsp, 0x28 \\n"'
@@ -366,7 +366,7 @@ class SysWhispers(object):
                 code += '\n\t\t"int 3 \\n"'
 
             if self.recovery in [SyscallRecoveryType.JUMPER, SyscallRecoveryType.JUMPER_RANDOMIZED]:
-                code += '\n\t\t"jmp r15 \\n"'
+                code += '\n\t\t"jmp r11 \\n"'
             elif self.recovery == SyscallRecoveryType.EGG_HUNTER:
                 for x in self.egg + self.egg:
                     code += f'\n\t\t"DB {x} \\n"'
@@ -486,7 +486,7 @@ class SysWhispers(object):
                     code += '\tcall SW3_GetRandomSyscallAddress        ; Get a syscall offset from a different api.\n'
                 else:
                     code += '\tcall SW3_GetSyscallAddress              ; Resolve function hash into syscall offset.\n'
-                code += '\tmov r15, rax                           ; Save the address of the syscall\n'
+                code += '\tmov r11, rax                           ; Save the address of the syscall\n'
                 code += f'\tmov ecx, 0{function_hash:08X}h        ; Re-Load function hash into ECX (optional).\n'
             code += '\tcall SW3_GetSyscallNumber              ; Resolve function hash into syscall number.\n'
             code += '\tadd rsp, 28h\n'
@@ -500,7 +500,7 @@ class SysWhispers(object):
                 code += '\tint 3\n'
 
             if self.recovery in [SyscallRecoveryType.JUMPER, SyscallRecoveryType.JUMPER_RANDOMIZED]:
-                code += '\tjmp r15                                ; Jump to -> Invoke system call.\n'
+                code += '\tjmp r11                                ; Jump to -> Invoke system call.\n'
             elif self.recovery == SyscallRecoveryType.EGG_HUNTER:
                 for x in self.egg + self.egg:
                     code += f'\tDB {x[2:]}h                     ; "{chr(int(x, 16)) if int(x, 16) != 0 else str(0)}"\n'


### PR DESCRIPTION
Addresses [Potentially unexpected behaviour by using r15 for sysenter #7
](https://github.com/klezVirus/SysWhispers3/issues/7)

See https://learn.microsoft.com/en-us/cpp/build/x64-software-conventions?view=msvc-170#register-volatility-and-preservation
